### PR TITLE
Allow accessing different parts of the tree through the metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,15 +645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "markdown"
-version = "1.0.0-alpha.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e61c5c85b392273c4d4ea546e6399ace3e3db172ab01b6de8f3d398d1dbd2ec"
-dependencies = [
- "unicode-id",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,7 +1149,6 @@ dependencies = [
  "env_logger",
  "figment",
  "log",
- "markdown",
  "minijinja",
  "notify",
  "notify-debouncer-full",
@@ -1447,12 +1437,6 @@ checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "unicode-id"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b6def86329695390197b82c1e244a54a131ceb66c996f2088a3876e2ae083f"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = { version = "4.5.10", features = ["derive"] }
 env_logger = "0.11.5"
 figment = { version = "0.10.19", features = ["env", "toml"] }
 log = "0.4.22"
-markdown = "1.0.0-alpha.18"
 minijinja = { version = "2.1.0", features = ["loader"] }
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use pulldown_cmark::Options;
 use crate::{
     config::{Config, ConfigDefaults, ConfigOptions, ConfigStructure},
     files::Dir,
+    meta::FileMeta,
     templates, OUT_DIR,
 };
 
@@ -47,10 +48,8 @@ impl<'a> App<'a> {
     }
 
     fn create_pages(&self) -> std::io::Result<()> {
-        let docs = self.content.documents(&self.options, &self.defaults);
-        for doc in docs {
-            doc.create(&self.templates)?;
-        }
+        let tree = FileMeta::from_dir(&self.content, &self.options, &self.defaults);
+        tree.traverse(&self.templates);
         Ok(())
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,42 +1,42 @@
 use figment::providers::{Format, Toml};
 use minijinja::Environment;
+use pulldown_cmark::Options;
 
-use crate::{config::Config, files::Dir, templates, OUT_DIR};
+use crate::{
+    config::{Config, ConfigDefaults, ConfigOptions, ConfigStructure},
+    files::Dir,
+    templates, OUT_DIR,
+};
 
 /// The app represents the state of the site to generate
-
-pub struct Info<'a> {
-    config: Config,
-    templates: Environment<'a>,
-}
-
-impl<'a> Info<'a> {
-    fn new() -> Self {
-        let config: Config = Config::figment()
-            .merge(Toml::file("sitdown.toml"))
-            .extract()
-            .unwrap();
-        let templates = templates::get_env(&config.template_dir).unwrap();
-        println!("config: {:?}", config);
-        println!("templates: {:?}", templates);
-        Self { config, templates }
-    }
-}
-
 pub struct App<'a> {
-    info: Info<'a>,
+    structure: ConfigStructure,
+    options: Options,
+    defaults: ConfigDefaults,
+    templates: Environment<'a>,
     content: Dir,
     assets: Dir,
 }
 
 impl<'a> App<'a> {
     pub fn new() -> Self {
-        let info = Info::new();
-        let content = Dir::new(&info.config.content_dir);
-        let assets = Dir::new(&info.config.asset_dir);
+        let config: Config = Config::figment()
+            .merge(Toml::file("sitdown.yaml"))
+            .extract()
+            .unwrap();
+        let structure = config.structure;
+        let options = config.options.options();
+        let defaults = config.defaults;
+
+        let templates = templates::get_env(&structure.template).unwrap();
+        let content = Dir::new(&structure.content);
+        let assets = Dir::new(&structure.assest);
 
         App {
-            info,
+            structure,
+            options,
+            defaults,
+            templates,
             content,
             assets,
         }
@@ -47,9 +47,9 @@ impl<'a> App<'a> {
     }
 
     fn create_pages(&self) -> std::io::Result<()> {
-        let docs = self.content.documents(&self.info.config);
+        let docs = self.content.documents(&self.options, &self.defaults);
         for doc in docs {
-            doc.create(&self.info.templates)?;
+            doc.create(&self.templates)?;
         }
         Ok(())
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// the page data, both the metadata and the contents of the file
-#[derive(Debug, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct Document {
     #[serde(flatten)]
     pub metadata: Metadata,
@@ -80,12 +80,9 @@ impl Document {
 
     pub fn create<'a>(&self, templates: &Environment<'a>) -> std::io::Result<()> {
         let layout = self.metadata.layout.as_ref();
-        println!("layout: {layout:?}");
         let template = templates.get_template(&layout).unwrap();
-        println!("values being passed: {:?}", Value::from_serialize(self));
         let content = template.render(Value::from_serialize(self)).unwrap();
         let path = PathBuf::from(OUT_DIR).join(&self.metadata.location);
-        println!("Creating: {path:?}");
         fs::create_dir_all(path.parent().unwrap())?;
         fs::write(path, content)?;
         Ok(())

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,9 +1,9 @@
 use core::panic;
-use minijinja::{context, value::Object, Environment, Value};
+use minijinja::{value::Object, Environment, Value};
 use pulldown_cmark::{
     CowStr::Borrowed,
     Event::{Start, Text},
-    Parser, Tag, TextMergeStream,
+    Options, Parser, Tag, TextMergeStream,
 };
 use serde::Serialize;
 use std::{
@@ -11,7 +11,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{config::Config, metadata::Metadata, path::PathData, OUT_DIR};
+use crate::{
+    config::ConfigDefaults,
+    metadata::{DefaultMetadata, FileMetadata, Metadata},
+    path::PathData,
+    OUT_DIR,
+};
 
 /// the page data, both the metadata and the contents of the file
 #[derive(Debug, Serialize)]
@@ -24,13 +29,8 @@ pub struct Document {
 impl Object for &Document {
     fn get_value(self: &std::sync::Arc<Self>, key: &minijinja::Value) -> Option<minijinja::Value> {
         match key.as_str()? {
-            "title" => self.metadata.title.as_ref().map(|s| Value::from(s)),
-            "location" => self
-                .metadata
-                .location
-                .as_ref()
-                .and_then(|s| s.to_str().to_owned())
-                .map(|s| Value::from(s)),
+            "title" => Some(Value::from(self.metadata.title.clone())),
+            "location" => self.metadata.location.to_str().map(|s| Value::from(s)),
             "content" => Some(Value::from(self.contents.clone())),
             s => {
                 if let Some(v) = self.metadata.meta.get(s) {
@@ -44,31 +44,27 @@ impl Object for &Document {
 }
 
 impl Document {
-    pub fn new<T: AsRef<Path>>(config: &Config, path: T) -> Self {
-        let config_data: Metadata = config.into();
-        println!("Config meta: {:?}", config_data);
-        let path_data: Metadata = PathData::from(path.as_ref()).into();
-        println!("path meta: {:?}", path_data);
-        let data = config_data.merge(path_data);
-        println!("combined meta: {:?}", data);
+    pub fn new<T: AsRef<Path>>(options: &Options, config: &ConfigDefaults, path: T) -> Self {
+        let path_data = PathData::from(path.as_ref());
+        let def_metadata = DefaultMetadata::new(config, path_data);
         let text = fs::read_to_string(path.as_ref()).unwrap();
-        let parser = Parser::new_ext(&text, config.options());
+        let parser = Parser::new_ext(&text, *options);
 
         let mut iterator = TextMergeStream::new(parser).peekable();
 
         let meta = if let Some(Start(Tag::MetadataBlock(_))) = iterator.peek() {
             iterator.next();
             let info = if let Some(Text(Borrowed(s))) = iterator.next() {
-                let res: Metadata = serde_yml::from_str(s).unwrap();
+                let res: FileMetadata = serde_yml::from_str(s).unwrap();
                 println!("parsed meta: {:?}", res);
                 iterator.next();
-                res.merge(data)
+                Metadata::new(def_metadata, res)
             } else {
                 panic!("Missing yaml from metadata block");
             };
             info
         } else {
-            data
+            def_metadata.into()
         };
 
         println!("final meta: {:?}", meta);
@@ -83,12 +79,12 @@ impl Document {
     }
 
     pub fn create<'a>(&self, templates: &Environment<'a>) -> std::io::Result<()> {
-        let layout = self.metadata.layout.as_ref().unwrap();
+        let layout = self.metadata.layout.as_ref();
         println!("layout: {layout:?}");
         let template = templates.get_template(&layout).unwrap();
         println!("values being passed: {:?}", Value::from_serialize(self));
         let content = template.render(Value::from_serialize(self)).unwrap();
-        let path = PathBuf::from(OUT_DIR).join(self.metadata.location.as_ref().unwrap());
+        let path = PathBuf::from(OUT_DIR).join(&self.metadata.location);
         println!("Creating: {path:?}");
         fs::create_dir_all(path.parent().unwrap())?;
         fs::write(path, content)?;

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,9 +1,10 @@
+use pulldown_cmark::Options;
 use std::{
     fs, io,
     path::{Path, PathBuf},
 };
 
-use crate::{config::Config, document::Document};
+use crate::{config::ConfigDefaults, document::Document};
 
 /// representation of the file structure
 /// make use of Object interface in jinja to make each piece have field accessors
@@ -114,9 +115,12 @@ impl Dir {
         Ok(())
     }
 
-    pub fn documents(&self, config: &Config) -> Vec<Document> {
-        let mut res: Vec<Document> = self.pages().map(|p| Document::new(config, p)).collect();
-        let subdirs = self.dirs().flat_map(|d| d.documents(config));
+    pub fn documents(&self, options: &Options, config: &ConfigDefaults) -> Vec<Document> {
+        let mut res: Vec<Document> = self
+            .pages()
+            .map(|p| Document::new(options, config, p))
+            .collect();
+        let subdirs = self.dirs().flat_map(|d| d.documents(options, config));
         res.extend(subdirs);
         res
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{config::ConfigDefaults, document::Document};
+use crate::{config::ConfigDefaults, document::Document, full_meta::DirMeta, meta::FileMeta};
 
 /// representation of the file structure
 /// make use of Object interface in jinja to make each piece have field accessors
@@ -72,18 +72,6 @@ impl Dir {
         }
     }
 
-    // // a dumb way of making the iterator that should be improved
-    // pub fn children(self) -> Vec<File> {
-    //     let mut files = Vec::new();
-    //     for page in self.pages {
-    //         files.push(File::Page(page));
-    //     }
-    //     for dir in self.subdirs {
-    //         files.push(File::Dir(dir));
-    //     }
-    //     files
-    // }
-
     pub fn pages<'a>(&'a self) -> PagesIter<'a> {
         PagesIter {
             pages: &self.pages,
@@ -123,6 +111,20 @@ impl Dir {
         let subdirs = self.dirs().flat_map(|d| d.documents(options, config));
         res.extend(subdirs);
         res
+    }
+
+    pub fn meta_tree(&self, options: &Options, config: &ConfigDefaults) -> FileMeta {
+        let mut entries = Vec::new();
+        for doc in self.documents(options, config) {
+            entries.push(FileMeta::from_doc(doc));
+        }
+        for dir in self.dirs() {
+            entries.push(dir.meta_tree(options, config));
+        }
+        FileMeta {
+            page: Document::default(),
+            entries,
+        }
     }
 
     // pub fn create_files<'a>(

--- a/src/full_meta.rs
+++ b/src/full_meta.rs
@@ -1,0 +1,14 @@
+use minijinja::value::Object;
+
+use crate::files::Dir;
+
+/// the metadata references for higher up the document tree, includes the root
+/// of the filesystem and the immediate parent of the page
+
+#[derive(Debug)]
+pub struct DirMeta<'a> {
+    pub root: &'a Dir,
+    pub parent: &'a Dir,
+}
+
+impl<'a> Object for DirMeta<'a> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ pub mod app;
 pub mod config;
 pub mod document;
 pub mod files;
+pub mod full_meta;
+pub mod meta;
 pub mod metadata;
 pub mod path;
 pub mod templates;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,0 +1,87 @@
+use std::{fs, path::PathBuf};
+
+use minijinja::{Environment, Value};
+use pulldown_cmark::Options;
+use serde::{Deserialize, Serialize};
+
+use crate::{config::ConfigDefaults, document::Document, files::Dir, metadata::Metadata, OUT_DIR};
+
+/// a representation of the metadata in the filetree
+/// that should be simple to access for the metadata in the rendering
+///
+/// in order to be convenient to access need to flatten the structure a bit
+/// and that is why a directory and a file share the same structure
+
+#[derive(Default, Debug, Serialize)]
+pub struct FileMeta {
+    #[serde(flatten)]
+    pub page: Document,
+    pub entries: Vec<FileMeta>,
+}
+
+impl FileMeta {
+    pub fn from_dir(dir: &Dir, options: &Options, config: &ConfigDefaults) -> Self {
+        let entries = dir
+            .pages()
+            .map(|p| Document::new(options, config, p))
+            .map(|d| FileMeta::from(d))
+            .chain(dir.dirs().map(|d| FileMeta::from_dir(d, options, config)))
+            .collect();
+        Self {
+            page: Document::default(),
+            entries,
+        }
+    }
+    pub fn from_doc(doc: Document) -> Self {
+        Self {
+            page: doc,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn traverse<'a>(&'a self, templates: &Environment<'a>) {
+        let mut meta = FullMeta {
+            root: self,
+            parent: self,
+            page: &FileMeta::default(),
+        };
+        self.traverse_meta(templates, &mut meta);
+    }
+
+    fn traverse_meta<'a>(&'a self, templates: &Environment<'a>, meta: &mut FullMeta<'a>) {
+        println!("processing: {:?}", self);
+        if self.entries.is_empty() {
+            // a page
+            meta.page = self;
+            let layout = self.page.metadata.layout.as_ref();
+            let template = templates.get_template(&layout).unwrap();
+            let content = template.render(Value::from_serialize(meta)).unwrap();
+            let path = PathBuf::from(OUT_DIR).join(&self.page.metadata.location);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, content).unwrap();
+        } else {
+            // directory
+            meta.parent = self;
+            for entry in &self.entries {
+                entry.traverse_meta(templates, meta);
+            }
+        }
+    }
+}
+
+impl From<Document> for FileMeta {
+    fn from(value: Document) -> Self {
+        Self {
+            page: value,
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FullMeta<'a> {
+    root: &'a FileMeta,
+    parent: &'a FileMeta,
+    #[serde(flatten)]
+    page: &'a FileMeta,
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -23,7 +23,7 @@ pub struct DefaultMetadata {
 }
 
 /// metadata that defines the template and parameters to give to the template
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Metadata {
     pub layout: String,
     pub title: String,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,64 +1,68 @@
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::{config::Config, path::PathData};
+use crate::{config::ConfigDefaults, path::PathData};
 
 /// the metadata associated with a page
 #[derive(Default, Debug, Serialize, Deserialize)]
-pub struct Metadata {
-    pub title: Option<String>,
-    pub location: Option<PathBuf>,
-    pub layout: Option<String>,
+pub struct FileMetadata {
+    layout: Option<String>,
+    title: Option<String>,
+    location: Option<PathBuf>,
     // technically making more assumptions than is strictly valid by putting the remaining yaml
     // into just a hashmap
+    #[serde(flatten)]
+    meta: HashMap<String, serde_yml::Value>,
+}
+
+/// metadata derived from the config and the filepath
+pub struct DefaultMetadata {
+    layout: String,
+    title: String,
+    location: PathBuf,
+}
+
+/// metadata that defines the template and parameters to give to the template
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    pub layout: String,
+    pub title: String,
+    pub location: PathBuf,
     #[serde(flatten)]
     pub meta: HashMap<String, serde_yml::Value>,
 }
 
-impl Metadata {
-    // fn title(mut self, title: impl Into<Option<String>>) -> Self {
-    //     self.title = title.into();
-    //     self
-    // }
-    // fn location(mut self, location: impl Into<Option<PathBuf>>) -> Self {
-    //     self.location = location.into();
-    //     self
-    // }
-    // fn layout(mut self, layout: impl Into<Option<String>>) -> Self {
-    //     self.layout = layout.into();
-    //     self
-    // }
-    // fn meta(mut self, meta: impl Into<HashMap<String, serde_yml::Value>>) -> Self {
-    //     self.meta = meta.into();
-    //     self
-    // }
-    pub fn merge(mut self, other: impl Into<Metadata>) -> Self {
-        let other = other.into();
-        self.title = self.title.or(other.title);
-        self.location = self.location.or(other.location);
-        self.layout = self.layout.or(other.layout);
-        self.meta.extend(other.meta);
-
-        self
-    }
-}
-
-impl From<PathData> for Metadata {
-    fn from(value: PathData) -> Self {
+impl DefaultMetadata {
+    pub fn new(config: &ConfigDefaults, path: PathData) -> Self {
         Self {
-            title: value.title.into(),
-            location: value.location.into(),
-            ..Default::default()
+            title: path.title,
+            location: path.location,
+            layout: config.page.clone(),
         }
-        // Self::default().title(value.title).location(value.location)
     }
 }
 
-impl From<&Config> for Metadata {
-    fn from(value: &Config) -> Self {
+impl From<DefaultMetadata> for Metadata {
+    fn from(value: DefaultMetadata) -> Self {
         Self {
-            layout: value.page_template.clone().into(),
-            ..Default::default()
+            title: value.title,
+            location: value.location,
+            layout: value.layout,
+            meta: HashMap::new(),
+        }
+    }
+}
+
+impl Metadata {
+    pub fn new(def: DefaultMetadata, file: FileMetadata) -> Self {
+        let title = file.title.unwrap_or(def.title);
+        let location = file.location.unwrap_or(def.location);
+        let layout = file.layout.unwrap_or(def.layout);
+        Self {
+            title,
+            location,
+            layout,
+            meta: file.meta,
         }
     }
 }


### PR DESCRIPTION
Allows a template to inspect the root directory and the parent directory at every page so that things like index pages and navigation can be generated.

It is a bit of a mess at this point though.